### PR TITLE
Fix save to file as stream

### DIFF
--- a/calcchain.go
+++ b/calcchain.go
@@ -9,7 +9,10 @@
 
 package excelize
 
-import "encoding/xml"
+import (
+	"archive/zip"
+	"encoding/xml"
+)
 
 // calcChainReader provides a function to get the pointer to the structure
 // after deserialization of xl/calcChain.xml.
@@ -24,11 +27,11 @@ func (f *File) calcChainReader() *xlsxCalcChain {
 
 // calcChainWriter provides a function to save xl/calcChain.xml after
 // serialize structure.
-func (f *File) calcChainWriter() {
+func (f File) calcChainWriter(zw *zip.Writer) error {
 	if f.CalcChain != nil && f.CalcChain.C != nil {
-		output, _ := xml.Marshal(f.CalcChain)
-		f.saveFileList("xl/calcChain.xml", output)
+		return writeXMLToZipWriter(zw, "xl/calcChain.xml", f.CalcChain)
 	}
+	return nil
 }
 
 // deleteCalcChain provides a function to remove cell reference on the

--- a/comment.go
+++ b/comment.go
@@ -10,6 +10,7 @@
 package excelize
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -316,13 +317,16 @@ func (f *File) decodeVMLDrawingReader(path string) *decodeVmlDrawing {
 
 // vmlDrawingWriter provides a function to save xl/drawings/vmlDrawing%d.xml
 // after serialize structure.
-func (f *File) vmlDrawingWriter() {
+func (f *File) vmlDrawingWriter(zw *zip.Writer) error {
 	for path, vml := range f.VMLDrawing {
-		if vml != nil {
-			v, _ := xml.Marshal(vml)
-			f.XLSX[path] = v
+		if vml == nil {
+			continue
+		}
+		if err := writeXMLToZipWriter(zw, path, vml); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 // commentsReader provides a function to get the pointer to the structure
@@ -341,11 +345,14 @@ func (f *File) commentsReader(path string) *xlsxComments {
 
 // commentsWriter provides a function to save xl/comments%d.xml after
 // serialize structure.
-func (f *File) commentsWriter() {
+func (f *File) commentsWriter(zw *zip.Writer) error {
 	for path, c := range f.Comments {
-		if c != nil {
-			v, _ := xml.Marshal(c)
-			f.saveFileList(path, v)
+		if c == nil {
+			continue
+		}
+		if err := writeXMLToZipWriter(zw, path, c); err != nil {
+			return err
 		}
 	}
+	return nil
 }

--- a/file.go
+++ b/file.go
@@ -11,7 +11,6 @@ package excelize
 
 import (
 	"archive/zip"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -76,44 +75,64 @@ func (f *File) SaveAs(name string) error {
 
 // Write provides a function to write to an io.Writer.
 func (f *File) Write(w io.Writer) error {
-	_, err := f.WriteTo(w)
-	return err
-}
-
-// WriteTo implements io.WriterTo to write the file.
-func (f *File) WriteTo(w io.Writer) (int64, error) {
-	buf, err := f.WriteToBuffer()
-	if err != nil {
-		return 0, err
-	}
-	return buf.WriteTo(w)
-}
-
-// WriteToBuffer provides a function to get bytes.Buffer from the saved file.
-func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
-	zw := zip.NewWriter(buf)
-	f.calcChainWriter()
-	f.commentsWriter()
-	f.contentTypesWriter()
-	f.drawingsWriter()
-	f.vmlDrawingWriter()
-	f.workBookWriter()
-	f.workSheetWriter()
-	f.relsWriter()
-	f.styleSheetWriter()
+	var err error
+	zw := zip.NewWriter(w)
+	isZipWriterClosed := false
+	defer func() {
+		if !isZipWriterClosed {
+			zw.Close()
+		}
+	}()
 
 	for path, content := range f.XLSX {
+		if path == "xl/styles.xml" || path == "xl/workbook.xml" || path == "[Content_Types].xml" {
+			continue
+		}
 		fi, err := zw.Create(path)
 		if err != nil {
-			zw.Close()
-			return buf, err
+			return err
 		}
 		_, err = fi.Write(content)
 		if err != nil {
-			zw.Close()
-			return buf, err
+			return err
 		}
 	}
-	return buf, zw.Close()
+	err = f.calcChainWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.commentsWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.contentTypesWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.drawingsWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.vmlDrawingWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.workBookWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.workSheetWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.relsWriter(zw)
+	if err != nil {
+		return err
+	}
+	err = f.styleSheetWriter(zw)
+	if err != nil {
+		return err
+	}
+	isZipWriterClosed = true
+	return zw.Close()
 }

--- a/lib.go
+++ b/lib.go
@@ -12,6 +12,7 @@ package excelize
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"log"
@@ -50,6 +51,30 @@ func (f *File) saveFileList(name string, content []byte) {
 	newContent = append(newContent, []byte(XMLHeader)...)
 	newContent = append(newContent, content...)
 	f.XLSX[name] = newContent
+}
+
+// writeXMLToZipWriter writes data obj in form of XML to zip,Writer
+func writeXMLToZipWriter(zw *zip.Writer, name string, data interface{}) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(XMLHeader))
+	if err != nil {
+		return err
+	}
+	encoder := xml.NewEncoder(w)
+	return encoder.Encode(data)
+}
+
+// writeStringToZipWriter writes string to zip,Writer
+func writeStringToZipWriter(zw *zip.Writer, name string, data string) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(XMLHeader + data))
+	return err
 }
 
 // Read file content as string in a archive file.

--- a/picture.go
+++ b/picture.go
@@ -10,6 +10,7 @@
 package excelize
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
@@ -522,11 +523,14 @@ func (f *File) getDrawingRelationships(rels, rID string) *xlsxRelationship {
 
 // drawingsWriter provides a function to save xl/drawings/drawing%d.xml after
 // serialize structure.
-func (f *File) drawingsWriter() {
+func (f *File) drawingsWriter(zw *zip.Writer) error {
 	for path, d := range f.Drawings {
-		if d != nil {
-			v, _ := xml.Marshal(d)
-			f.saveFileList(path, v)
+		if d == nil {
+			continue
+		}
+		if err := writeXMLToZipWriter(zw, path, d); err != nil {
+			return err
 		}
 	}
+	return nil
 }

--- a/sheet.go
+++ b/sheet.go
@@ -10,6 +10,7 @@
 package excelize
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
@@ -71,11 +72,11 @@ func (f *File) contentTypesReader() *xlsxTypes {
 
 // contentTypesWriter provides a function to save [Content_Types].xml after
 // serialize structure.
-func (f *File) contentTypesWriter() {
+func (f *File) contentTypesWriter(zw *zip.Writer) error {
 	if f.ContentTypes != nil {
-		output, _ := xml.Marshal(f.ContentTypes)
-		f.saveFileList("[Content_Types].xml", output)
+		return writeXMLToZipWriter(zw, "[Content_Types].xml", f.ContentTypes)
 	}
+	return writeStringToZipWriter(zw, "[Content_Types].xml", templateContentTypes)
 }
 
 // workbookReader provides a function to get the pointer to the xl/workbook.xml
@@ -91,30 +92,29 @@ func (f *File) workbookReader() *xlsxWorkbook {
 
 // workBookWriter provides a function to save xl/workbook.xml after serialize
 // structure.
-func (f *File) workBookWriter() {
+func (f *File) workBookWriter(zw *zip.Writer) error {
 	if f.WorkBook != nil {
-		output, _ := xml.Marshal(f.WorkBook)
-		f.saveFileList("xl/workbook.xml", replaceRelationshipsBytes(replaceRelationshipsNameSpaceBytes(output)))
+		return writeXMLToZipWriter(zw, "xl/workbook.xml", f.WorkBook)
 	}
+	return writeStringToZipWriter(zw, "xl/workbook.xml", templateWorkbook)
 }
 
 // workSheetWriter provides a function to save xl/worksheets/sheet%d.xml after
 // serialize structure.
-func (f *File) workSheetWriter() {
+func (f *File) workSheetWriter(zw *zip.Writer) error {
 	for p, sheet := range f.Sheet {
-		if sheet != nil {
-			for k, v := range sheet.SheetData.Row {
-				f.Sheet[p].SheetData.Row[k].C = trimCell(v.C)
-			}
-			output, _ := xml.Marshal(sheet)
-			f.saveFileList(p, replaceRelationshipsBytes(replaceWorkSheetsRelationshipsNameSpaceBytes(output)))
-			ok := f.checked[p]
-			if ok {
-				delete(f.Sheet, p)
-				f.checked[p] = false
-			}
+		if sheet == nil {
+			continue
+		}
+		for k, v := range sheet.SheetData.Row {
+			f.Sheet[p].SheetData.Row[k].C = trimCell(v.C)
+		}
+		err := writeXMLToZipWriter(zw, p, sheet)
+		if err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 // trimCell provides a function to trim blank cells which created by completeCol.
@@ -165,16 +165,16 @@ func (f *File) setWorkbook(name string, sheetID, rid int) {
 
 // relsWriter provides a function to save relationships after
 // serialize structure.
-func (f *File) relsWriter() {
+func (f *File) relsWriter(zw *zip.Writer) error {
 	for path, rel := range f.Relationships {
-		if rel != nil {
-			output, _ := xml.Marshal(rel)
-			if strings.HasPrefix(path, "xl/worksheets/sheet/rels/sheet") {
-				output = replaceWorkSheetsRelationshipsNameSpaceBytes(output)
-			}
-			f.saveFileList(path, replaceRelationshipsBytes(output))
+		if rel == nil {
+			continue
+		}
+		if err := writeXMLToZipWriter(zw, path, rel); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 // setAppXML update docProps/app.xml file of XML.

--- a/styles.go
+++ b/styles.go
@@ -10,6 +10,7 @@
 package excelize
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -1007,11 +1008,11 @@ func (f *File) stylesReader() *xlsxStyleSheet {
 
 // styleSheetWriter provides a function to save xl/styles.xml after serialize
 // structure.
-func (f *File) styleSheetWriter() {
+func (f *File) styleSheetWriter(zw *zip.Writer) error {
 	if f.Styles != nil {
-		output, _ := xml.Marshal(f.Styles)
-		f.saveFileList("xl/styles.xml", replaceStyleRelationshipsNameSpaceBytes(output))
+		return writeXMLToZipWriter(zw, "xl/styles.xml", f.Styles)
 	}
+	return writeStringToZipWriter(zw, "xl/styles.xml", templateStyles)
 }
 
 // parseFormatStyleSet provides a function to parse the format settings of the

--- a/xmlStyles.go
+++ b/xmlStyles.go
@@ -29,6 +29,66 @@ type xlsxStyleSheet struct {
 	ExtLst       *xlsxExtLst       `xml:"extLst"`
 }
 
+func (sheet xlsxStyleSheet) MarshalXML(encoder *xml.Encoder, start xml.StartElement) error {
+	sheet2 := struct {
+		XMLName      xml.Name          `xml:"styleSheet"`
+		NumFmts      *xlsxNumFmts      `xml:"numFmts,omitempty"`
+		Fonts        *xlsxFonts        `xml:"fonts,omitempty"`
+		Fills        *xlsxFills        `xml:"fills,omitempty"`
+		Borders      *xlsxBorders      `xml:"borders,omitempty"`
+		CellStyleXfs *xlsxCellStyleXfs `xml:"cellStyleXfs,omitempty"`
+		CellXfs      *xlsxCellXfs      `xml:"cellXfs,omitempty"`
+		CellStyles   *xlsxCellStyles   `xml:"cellStyles,omitempty"`
+		Dxfs         *xlsxDxfs         `xml:"dxfs,omitempty"`
+		TableStyles  *xlsxTableStyles  `xml:"tableStyles,omitempty"`
+		Colors       *xlsxStyleColors  `xml:"colors,omitempty"`
+		ExtLst       *xlsxExtLst       `xml:"extLst"`
+		XrUID        string            `xml:"xr:uid,attr"`
+		XmlnsXr      string            `xml:"xmlns:xr,attr"`
+		XmlnsXr2     string            `xml:"xmlns:xr2,attr"`
+		XmlnsXr3     string            `xml:"xmlns:xr3,attr"`
+		XmlnsXr6     string            `xml:"xmlns:xr6,attr"`
+		XmlnsXr10    string            `xml:"xmlns:xr10,attr"`
+		XmlnsXr14    string            `xml:"xmlns:xr14,attr"`
+		XmlnsXr14ac  string            `xml:"xmlns:xr14ac,attr"`
+		XmlnsXr15    string            `xml:"xmlns:xr15,attr"`
+		McIgnorable  string            `xml:"mc:Ignorable,attr"`
+		XmlnsMc      string            `xml:"xmlns:mc,attr"`
+		XmlnsMx      string            `xml:"xmlns:mx,attr"`
+		XmlnsMv      string            `xml:"xmlns:mv,attr"`
+		XmlnsR       string            `xml:"xmlns:r,attr"`
+		Xmlns        string            `xml:"xmlns,attr"`
+	}{
+		XMLName:      sheet.XMLName,
+		NumFmts:      sheet.NumFmts,
+		Fonts:        sheet.Fonts,
+		Fills:        sheet.Fills,
+		Borders:      sheet.Borders,
+		CellStyleXfs: sheet.CellStyleXfs,
+		CellXfs:      sheet.CellXfs,
+		Dxfs:         sheet.Dxfs,
+		TableStyles:  sheet.TableStyles,
+		Colors:       sheet.Colors,
+		ExtLst:       sheet.ExtLst,
+		XrUID:        "{00000000-0001-0000-0000-000000000000}",
+		XmlnsXr:      "http://schemas.microsoft.com/office/spreadsheetml/2014/revision",
+		XmlnsXr2:     "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2",
+		XmlnsXr3:     "http://schemas.microsoft.com/office/spreadsheetml/2016/revision3",
+		XmlnsXr6:     "http://schemas.microsoft.com/office/spreadsheetml/2016/revision6",
+		XmlnsXr10:    "http://schemas.microsoft.com/office/spreadsheetml/2016/revision10",
+		XmlnsXr14:    "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main",
+		XmlnsXr14ac:  "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac",
+		XmlnsXr15:    "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main",
+		McIgnorable:  "x14ac xr xr2 xr3 xr6 xr10 x15",
+		XmlnsMc:      "http://schemas.openxmlformats.org/markup-compatibility/2006",
+		XmlnsMx:      "http://schemas.microsoft.com/office/mac/excel/2008/main",
+		XmlnsMv:      "urn:schemas-microsoft-com:mac:vml",
+		XmlnsR:       "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+		Xmlns:        "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+	}
+	return encoder.Encode(sheet2)
+}
+
 // xlsxAlignment formatting information pertaining to text alignment in cells.
 // There are a variety of choices for how text is aligned both horizontally and
 // vertically, as well as indentation settings, and so on.

--- a/xmlStyles_test.go
+++ b/xmlStyles_test.go
@@ -1,0 +1,19 @@
+package excelize
+
+import (
+	"encoding/xml"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestXlsxStyleSheet_MarshalXML(t *testing.T) {
+	relationships := xlsxStyleSheet{}
+
+	b, err := xml.Marshal(relationships)
+	require.NoError(t, err)
+
+	b2 := replaceStyleRelationshipsNameSpaceBytes(b)
+	t.Log(string(b))
+	t.Log(string(b2))
+	require.Equal(t, string(b), string(b2))
+}

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -44,6 +44,70 @@ type xlsxWorkbook struct {
 	FileRecoveryPr      *xlsxFileRecoveryPr      `xml:"fileRecoveryPr"`
 }
 
+// MarshalXML implements xml.Marshaler
+func (x xlsxWorkbook) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	x2 := struct {
+		XMLName             xml.Name                 `xml:"workbook"`
+		FileVersion         *xlsxFileVersion         `xml:"fileVersion"`
+		WorkbookPr          *xlsxWorkbookPr          `xml:"workbookPr"`
+		WorkbookProtection  *xlsxWorkbookProtection  `xml:"workbookProtection"`
+		BookViews           xlsxBookViews            `xml:"bookViews"`
+		Sheets              xlsxSheets               `xml:"sheets"`
+		ExternalReferences  *xlsxExternalReferences  `xml:"externalReferences"`
+		DefinedNames        *xlsxDefinedNames        `xml:"definedNames"`
+		CalcPr              *xlsxCalcPr              `xml:"calcPr"`
+		CustomWorkbookViews *xlsxCustomWorkbookViews `xml:"customWorkbookViews"`
+		PivotCaches         *xlsxPivotCaches         `xml:"pivotCaches"`
+		ExtLst              *xlsxExtLst              `xml:"extLst"`
+		FileRecoveryPr      *xlsxFileRecoveryPr      `xml:"fileRecoveryPr"`
+		XrUID               string                   `xml:"xr:uid,attr"`
+		XmlnsXr             string                   `xml:"xmlns:xr,attr"`
+		XmlnsXr2            string                   `xml:"xmlns:xr2,attr"`
+		XmlnsXr3            string                   `xml:"xmlns:xr3,attr"`
+		XmlnsXr6            string                   `xml:"xmlns:xr6,attr"`
+		XmlnsXr10           string                   `xml:"xmlns:xr10,attr"`
+		XmlnsXr14           string                   `xml:"xmlns:xr14,attr"`
+		XmlnsXr14ac         string                   `xml:"xmlns:xr14ac,attr"`
+		XmlnsXr15           string                   `xml:"xmlns:xr15,attr"`
+		McIgnorable         string                   `xml:"mc:Ignorable,attr"`
+		XmlnsMc             string                   `xml:"xmlns:mc,attr"`
+		XmlnsMx             string                   `xml:"xmlns:mx,attr"`
+		XmlnsMv             string                   `xml:"xmlns:mv,attr"`
+		XmlnsR              string                   `xml:"xmlns:r,attr"`
+		Xmlns               string                   `xml:"xmlns,attr"`
+	}{
+		XMLName:             x.XMLName,
+		FileVersion:         x.FileVersion,
+		WorkbookPr:          x.WorkbookPr,
+		WorkbookProtection:  x.WorkbookProtection,
+		BookViews:           x.BookViews,
+		Sheets:              x.Sheets,
+		ExternalReferences:  x.ExternalReferences,
+		DefinedNames:        x.DefinedNames,
+		CalcPr:              x.CalcPr,
+		CustomWorkbookViews: x.CustomWorkbookViews,
+		PivotCaches:         x.PivotCaches,
+		ExtLst:              x.ExtLst,
+		FileRecoveryPr:      x.FileRecoveryPr,
+		XrUID:               "{00000000-0001-0000-0000-000000000000}",
+		XmlnsXr:             "http://schemas.microsoft.com/office/spreadsheetml/2014/revision",
+		XmlnsXr2:            "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2",
+		XmlnsXr3:            "http://schemas.microsoft.com/office/spreadsheetml/2016/revision3",
+		XmlnsXr6:            "http://schemas.microsoft.com/office/spreadsheetml/2016/revision6",
+		XmlnsXr10:           "http://schemas.microsoft.com/office/spreadsheetml/2016/revision10",
+		XmlnsXr14:           "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main",
+		XmlnsXr14ac:         "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac",
+		XmlnsXr15:           "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main",
+		McIgnorable:         "x14ac xr xr2 xr3 xr6 xr10 x15",
+		XmlnsMc:             "http://schemas.openxmlformats.org/markup-compatibility/2006",
+		XmlnsMx:             "http://schemas.microsoft.com/office/mac/excel/2008/main",
+		XmlnsMv:             "urn:schemas-microsoft-com:mac:vml",
+		XmlnsR:              "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+		Xmlns:               "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+	}
+	return e.Encode(x2)
+}
+
 // xlsxFileRecoveryPr maps sheet recovery information. This element defines
 // properties that track the state of the workbook file, such as whether the
 // file was saved during a crash, or whether it should be opened in auto-recover
@@ -155,6 +219,23 @@ type xlsxSheet struct {
 	State   string `xml:"state,attr,omitempty"`
 }
 
+type tmpXlsxSheet struct {
+	XMLName xml.Name `xml:"sheet"`
+	Name    string   `xml:"name,attr,omitempty"`
+	SheetID int      `xml:"sheetId,attr,omitempty"`
+	ID      string   `xml:"r:id,attr,omitempty"`
+	State   string   `xml:"state,attr,omitempty"`
+}
+
+func (x *xlsxSheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxSheet{
+		Name:    x.Name,
+		SheetID: x.SheetID,
+		ID:      x.ID,
+		State:   x.State,
+	})
+}
+
 // xlsxExternalReferences directly maps the externalReferences element of the
 // external workbook references part.
 type xlsxExternalReferences struct {
@@ -177,6 +258,19 @@ type xlsxPivotCaches struct {
 type xlsxPivotCache struct {
 	CacheID int    `xml:"cacheId,attr"`
 	RID     string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
+}
+
+type tmpXlsxPivotCache struct {
+	XMLName xml.Name `xml:"pivotCache"`
+	RID     string   `xml:"r:id,attr,omitempty"`
+	CacheID int      `xml:"cacheId,attr"`
+}
+
+func (x *xlsxPivotCache) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxPivotCache{
+		RID:     x.RID,
+		CacheID: x.CacheID,
+	})
 }
 
 // extLst element provides a convention for extending spreadsheetML in

--- a/xmlWorkbook_test.go
+++ b/xmlWorkbook_test.go
@@ -1,0 +1,58 @@
+package excelize
+
+import (
+	"encoding/xml"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestXmlWorkBook_MarshalXML(t *testing.T) {
+	workBook := xlsxWorkbook{
+		FileVersion: &xlsxFileVersion{
+			AppName: "aaaa",
+		},
+		Sheets: xlsxSheets{
+			Sheet: []xlsxSheet{
+				{
+					Name: "name",
+					ID:   "id",
+				},
+			},
+		},
+		PivotCaches: &xlsxPivotCaches{
+			PivotCache: []xlsxPivotCache{
+				{
+					CacheID: 5,
+					RID:     "6",
+				},
+			},
+		},
+	}
+
+	b, err := xml.Marshal(workBook)
+	require.NoError(t, err)
+
+	b2 := replaceRelationshipsBytes(replaceRelationshipsNameSpaceBytes(b))
+	t.Log(string(b2))
+	require.Equal(t, string(b), string(b2))
+}
+
+func TestXlsxRelationships_MarshalXML(t *testing.T) {
+	relationships := xlsxRelationships{
+		Relationships: []xlsxRelationship{
+			{
+				ID:         "ID",
+				Type:       "Type",
+				Target:     "Target",
+				TargetMode: "TargetMode",
+			},
+		},
+	}
+
+	b, err := xml.Marshal(relationships)
+	require.NoError(t, err)
+
+	b2 := replaceRelationshipsBytes(replaceWorkSheetsRelationshipsNameSpaceBytes(b))
+	t.Log(string(b))
+	require.Equal(t, string(b), string(b2))
+}

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -9,7 +9,9 @@
 
 package excelize
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 // xlsxWorksheet directly maps the worksheet element in the namespace
 // http://schemas.openxmlformats.org/spreadsheetml/2006/main - currently I have
@@ -43,9 +45,112 @@ type xlsxWorksheet struct {
 	ExtLst                *xlsxExtLst                  `xml:"extLst"`
 }
 
+// MarshalXML implements xml.Marshaler
+func (x xlsxWorksheet) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	x2 := struct {
+		XMLName               xml.Name                     `xml:"worksheet"`
+		SheetPr               *xlsxSheetPr                 `xml:"sheetPr"`
+		Dimension             xlsxDimension                `xml:"dimension"`
+		SheetViews            xlsxSheetViews               `xml:"sheetViews,omitempty"`
+		SheetFormatPr         *xlsxSheetFormatPr           `xml:"sheetFormatPr"`
+		Cols                  *xlsxCols                    `xml:"cols,omitempty"`
+		SheetData             xlsxSheetData                `xml:"sheetData"`
+		SheetProtection       *xlsxSheetProtection         `xml:"sheetProtection"`
+		AutoFilter            *xlsxAutoFilter              `xml:"autoFilter"`
+		CustomSheetViews      *xlsxCustomSheetViews        `xml:"customSheetViews"`
+		MergeCells            *xlsxMergeCells              `xml:"mergeCells"`
+		PhoneticPr            *xlsxPhoneticPr              `xml:"phoneticPr"`
+		ConditionalFormatting []*xlsxConditionalFormatting `xml:"conditionalFormatting"`
+		DataValidations       *xlsxDataValidations         `xml:"dataValidations,omitempty"`
+		Hyperlinks            *xlsxHyperlinks              `xml:"hyperlinks"`
+		PrintOptions          *xlsxPrintOptions            `xml:"printOptions"`
+		PageMargins           *xlsxPageMargins             `xml:"pageMargins"`
+		PageSetUp             *xlsxPageSetUp               `xml:"pageSetup"`
+		HeaderFooter          *xlsxHeaderFooter            `xml:"headerFooter"`
+		RowBreaks             *xlsxBreaks                  `xml:"rowBreaks"`
+		ColBreaks             *xlsxBreaks                  `xml:"colBreaks"`
+		Drawing               *xlsxDrawing                 `xml:"drawing"`
+		LegacyDrawing         *xlsxLegacyDrawing           `xml:"legacyDrawing"`
+		Picture               *xlsxPicture                 `xml:"picture"`
+		TableParts            *xlsxTableParts              `xml:"tableParts"`
+		ExtLst                *xlsxExtLst                  `xml:"extLst"`
+		XrUID                 string                       `xml:"xr:uid,attr"`
+		XmlnsXr               string                       `xml:"xmlns:xr,attr"`
+		XmlnsXr2              string                       `xml:"xmlns:xr2,attr"`
+		XmlnsXr3              string                       `xml:"xmlns:xr3,attr"`
+		XmlnsXr6              string                       `xml:"xmlns:xr6,attr"`
+		XmlnsXr10             string                       `xml:"xmlns:xr10,attr"`
+		XmlnsXr14             string                       `xml:"xmlns:xr14,attr"`
+		XmlnsXr14ac           string                       `xml:"xmlns:xr14ac,attr"`
+		XmlnsXr15             string                       `xml:"xmlns:xr15,attr"`
+		McIgnorable           string                       `xml:"mc:Ignorable,attr"`
+		XmlnsMc               string                       `xml:"xmlns:mc,attr"`
+		XmlnsMx               string                       `xml:"xmlns:mx,attr"`
+		XmlnsMv               string                       `xml:"xmlns:mv,attr"`
+		XmlnsR                string                       `xml:"xmlns:r,attr"`
+		Xmlns                 string                       `xml:"xmlns,attr"`
+	}{
+		XMLName:               x.XMLName,
+		SheetPr:               x.SheetPr,
+		Dimension:             x.Dimension,
+		SheetViews:            x.SheetViews,
+		SheetFormatPr:         x.SheetFormatPr,
+		Cols:                  x.Cols,
+		SheetData:             x.SheetData,
+		SheetProtection:       x.SheetProtection,
+		AutoFilter:            x.AutoFilter,
+		CustomSheetViews:      x.CustomSheetViews,
+		MergeCells:            x.MergeCells,
+		PhoneticPr:            x.PhoneticPr,
+		ConditionalFormatting: x.ConditionalFormatting,
+		DataValidations:       x.DataValidations,
+		Hyperlinks:            x.Hyperlinks,
+		PrintOptions:          x.PrintOptions,
+		PageMargins:           x.PageMargins,
+		PageSetUp:             x.PageSetUp,
+		HeaderFooter:          x.HeaderFooter,
+		RowBreaks:             x.RowBreaks,
+		ColBreaks:             x.ColBreaks,
+		Drawing:               x.Drawing,
+		LegacyDrawing:         x.LegacyDrawing,
+		Picture:               x.Picture,
+		TableParts:            x.TableParts,
+		ExtLst:                x.ExtLst,
+		XrUID:                 "{00000000-0001-0000-0000-000000000000}",
+		XmlnsXr:               "http://schemas.microsoft.com/office/spreadsheetml/2014/revision",
+		XmlnsXr2:              "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2",
+		XmlnsXr3:              "http://schemas.microsoft.com/office/spreadsheetml/2016/revision3",
+		XmlnsXr6:              "http://schemas.microsoft.com/office/spreadsheetml/2016/revision6",
+		XmlnsXr10:             "http://schemas.microsoft.com/office/spreadsheetml/2016/revision10",
+		XmlnsXr14:             "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main",
+		XmlnsXr14ac:           "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac",
+		XmlnsXr15:             "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main",
+		McIgnorable:           "x14ac xr xr2 xr3 xr6 xr10 x15",
+		XmlnsMc:               "http://schemas.openxmlformats.org/markup-compatibility/2006",
+		XmlnsMx:               "http://schemas.microsoft.com/office/mac/excel/2008/main",
+		XmlnsMv:               "urn:schemas-microsoft-com:mac:vml",
+		XmlnsR:                "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+		Xmlns:                 "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+	}
+	return e.Encode(x2)
+}
+
 // xlsxDrawing change r:id to rid in the namespace.
 type xlsxDrawing struct {
 	RID string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
+}
+
+// tmpXlsxDrawing is temp struct for marshal xlsxDrawing to xml
+type tmpXlsxDrawing struct {
+	XMLName xml.Name `xml:"drawing"`
+	RID     string   `xml:"r:id,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (drawing *xlsxDrawing) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxDrawing{
+		RID: drawing.RID,
+	})
 }
 
 // xlsxHeaderFooter directly maps the headerFooter element in the namespace
@@ -103,6 +208,55 @@ type xlsxPageSetUp struct {
 	UseFirstPageNumber bool    `xml:"useFirstPageNumber,attr,omitempty"`
 	UsePrinterDefaults bool    `xml:"usePrinterDefaults,attr,omitempty"`
 	VerticalDPI        float32 `xml:"verticalDpi,attr,omitempty"`
+}
+
+// tmpXlsxDrawing is temp struct for marshal xlsxDrawing to xml
+type tmpXlsxPageSetUp struct {
+	XMLName            xml.Name `xml:"pageSetup"`
+	RID                string   `xml:"r:id,attr,omitempty"`
+	BlackAndWhite      bool     `xml:"blackAndWhite,attr,omitempty"`
+	CellComments       string   `xml:"cellComments,attr,omitempty"`
+	Copies             int      `xml:"copies,attr,omitempty"`
+	Draft              bool     `xml:"draft,attr,omitempty"`
+	Errors             string   `xml:"errors,attr,omitempty"`
+	FirstPageNumber    int      `xml:"firstPageNumber,attr,omitempty"`
+	FitToHeight        int      `xml:"fitToHeight,attr,omitempty"`
+	FitToWidth         int      `xml:"fitToWidth,attr,omitempty"`
+	HorizontalDPI      float32  `xml:"horizontalDpi,attr,omitempty"`
+	Orientation        string   `xml:"orientation,attr,omitempty"`
+	PageOrder          string   `xml:"pageOrder,attr,omitempty"`
+	PaperHeight        string   `xml:"paperHeight,attr,omitempty"`
+	PaperSize          int      `xml:"paperSize,attr,omitempty"`
+	PaperWidth         string   `xml:"paperWidth,attr,omitempty"`
+	Scale              int      `xml:"scale,attr,omitempty"`
+	UseFirstPageNumber bool     `xml:"useFirstPageNumber,attr,omitempty"`
+	UsePrinterDefaults bool     `xml:"usePrinterDefaults,attr,omitempty"`
+	VerticalDPI        float32  `xml:"verticalDpi,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (setUp *xlsxPageSetUp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxPageSetUp{
+		RID:                setUp.RID,
+		BlackAndWhite:      setUp.BlackAndWhite,
+		CellComments:       setUp.CellComments,
+		Copies:             setUp.Copies,
+		Draft:              setUp.Draft,
+		Errors:             setUp.Errors,
+		FirstPageNumber:    setUp.FirstPageNumber,
+		FitToHeight:        setUp.FitToHeight,
+		FitToWidth:         setUp.FitToWidth,
+		HorizontalDPI:      setUp.HorizontalDPI,
+		Orientation:        setUp.Orientation,
+		PageOrder:          setUp.PageOrder,
+		PaperHeight:        setUp.PaperHeight,
+		PaperSize:          setUp.PaperSize,
+		PaperWidth:         setUp.PaperWidth,
+		Scale:              setUp.Scale,
+		UseFirstPageNumber: setUp.UseFirstPageNumber,
+		UsePrinterDefaults: setUp.UsePrinterDefaults,
+		VerticalDPI:        setUp.VerticalDPI,
+	})
 }
 
 // xlsxPrintOptions directly maps the printOptions element in the namespace
@@ -562,6 +716,25 @@ type xlsxHyperlink struct {
 	RID      string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
 }
 
+// tmpXlsxHyperlink is temp struct for marshal xlsxHyperlink to xml
+type tmpXlsxHyperlink struct {
+	XMLName  xml.Name `xml:"hyperlink"`
+	RID      string   `xml:"r:id,attr,omitempty"`
+	Ref      string   `xml:"ref,attr"`
+	Location string   `xml:"location,attr,omitempty"`
+	Display  string   `xml:"display,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (hyperlink *xlsxHyperlink) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxHyperlink{
+		RID:      hyperlink.RID,
+		Ref:      hyperlink.Ref,
+		Location: hyperlink.Location,
+		Display:  hyperlink.Display,
+	})
+}
+
 // xlsxTableParts directly maps the tableParts element in the namespace
 // http://schemas.openxmlformats.org/spreadsheetml/2006/main - The table element
 // has several attributes applied to identify the table and the data range it
@@ -604,6 +777,19 @@ type xlsxTablePart struct {
 	RID string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
 }
 
+// tmpXlsxTablePart is temp struct for marshal xlsxTablePart to xml
+type tmpXlsxTablePart struct {
+	XMLName xml.Name `xml:"tablePart"`
+	RID     string   `xml:"r:id,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (p *xlsxTablePart) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxTablePart{
+		RID: p.RID,
+	})
+}
+
 // xlsxPicture directly maps the picture element in the namespace
 // http://schemas.openxmlformats.org/spreadsheetml/2006/main - Background sheet
 // image. For example:
@@ -612,6 +798,19 @@ type xlsxTablePart struct {
 //
 type xlsxPicture struct {
 	RID string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
+}
+
+// tmpXlsxPicture is temp struct for marshal xlsxPicture to xml
+type tmpXlsxPicture struct {
+	XMLName xml.Name `xml:"picture"`
+	RID     string   `xml:"r:id,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (picture *xlsxPicture) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxPicture{
+		RID: picture.RID,
+	})
 }
 
 // xlsxLegacyDrawing directly maps the legacyDrawing element in the namespace
@@ -625,6 +824,19 @@ type xlsxPicture struct {
 // something special about the cell.
 type xlsxLegacyDrawing struct {
 	RID string `xml:"http://schemas.openxmlformats.org/officeDocument/2006/relationships id,attr,omitempty"`
+}
+
+// tmpXlsxTablePart is temp struct for marshal xlsxLegacyDrawing to xml
+type tmpXlsxLegacyDrawing struct {
+	XMLName xml.Name `xml:"legacyDrawing"`
+	RID     string   `xml:"r:id,attr,omitempty"`
+}
+
+// MarshalXML implements xml.Marshaler
+func (p *xlsxLegacyDrawing) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.Encode(tmpXlsxLegacyDrawing{
+		RID: p.RID,
+	})
 }
 
 // xlsxWorksheetExt directly maps the ext element in the worksheet.

--- a/xmlWorksheet_test.go
+++ b/xmlWorksheet_test.go
@@ -1,0 +1,43 @@
+package excelize
+
+import (
+	"encoding/xml"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestXmlWorksheet_MarshalXML(t *testing.T) {
+	worksheet := xlsxWorksheet{
+		PageSetUp: &xlsxPageSetUp{
+			RID:           "aaa",
+			BlackAndWhite: true,
+		},
+		Hyperlinks: &xlsxHyperlinks{
+			Hyperlink: []xlsxHyperlink{
+				{
+					Ref: "google.com",
+					RID: "bbbbb",
+				},
+			},
+		},
+		TableParts: &xlsxTableParts{
+			TableParts: []*xlsxTablePart{
+				{
+					RID: "ccccc",
+				},
+			},
+		},
+		Picture: &xlsxPicture{
+			RID: "dddd",
+		},
+		LegacyDrawing: &xlsxLegacyDrawing{
+			RID: "eeee",
+		},
+	}
+	b, err := xml.Marshal(worksheet)
+	require.NoError(t, err)
+
+	b2 := replaceRelationshipsBytes(replaceWorkSheetsRelationshipsNameSpaceBytes(b))
+	t.Log(string(b))
+	require.Equal(t, string(b), string(b2))
+}


### PR DESCRIPTION
# PR Details
- Change the write method from writing to a bytes.Buffer to writing a stream to io.Writer

## Description
- create a zip.Writer from io.Writer
- for each components, create a new file then using a xml.Encoder() and write to io.Writer
- using custom unmarshalXML to avoid using this block of code
```

func replaceRelationshipsBytes(content []byte) []byte {
	oldXmlns := []byte(`xmlns:relationships="http://schemas.openxmlformats.org/officeDocument/2006/relationships" relationships`)
	newXmlns := []byte("r")
	return bytes.Replace(content, oldXmlns, newXmlns, -1)
}
```

## Related Issue
https://github.com/360EntSecGroup-Skylar/excelize/issues/487

## Motivation and Context
improve performance and reduce memory for storing XML data

## How Has This Been Tested
- writing a unit test for comparing custom unmarshal function and bytes.Replace result

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
